### PR TITLE
Feat: Support customizing REST for subresource

### DIFF
--- a/cmd/apiregister-gen/generators/parser.go
+++ b/cmd/apiregister-gen/generators/parser.go
@@ -473,6 +473,8 @@ func ParseSubresourceTag(c *APIResource, tag string) SubresourceTags {
 			result.RequestKind = value
 		case "rest":
 			result.REST = value
+		case "kind":
+			result.Kind = value
 		case "path":
 			// Strip the parent resource
 			result.Path = strings.Replace(value, c.Resource+"/", "", -1)

--- a/cmd/apiregister-gen/generators/unversioned_generator.go
+++ b/cmd/apiregister-gen/generators/unversioned_generator.go
@@ -85,7 +85,7 @@ var (
 		func() runtime.Object { return &{{ $api.Kind }}List{} },
 	)
 	{{ range $subresource := .Subresources -}}
-	Internal{{$subresource.REST}} = builders.NewInternalSubresource(
+	Internal{{$subresource.Kind}}REST = builders.NewInternalSubresource(
 		"{{$subresource.Resource}}", "{{$subresource.Request}}", "{{$subresource.Path}}",
 		func() runtime.Object { return &{{$subresource.Request}}{} },
 	)
@@ -98,7 +98,7 @@ var (
 		Internal{{$api.Kind}},
 		Internal{{$api.Kind}}Status,
 		{{ range $subresource := $api.Subresources -}}
-		Internal{{$subresource.REST}},
+		Internal{{$subresource.Kind}}REST,
 		{{ end -}}
 		{{ end -}}
 	)

--- a/cmd/apiregister-gen/generators/versioned_generator.go
+++ b/cmd/apiregister-gen/generators/versioned_generator.go
@@ -105,11 +105,13 @@ var (
 
 		{{ range $subresource := $api.Subresources -}}
 		builders.NewApiResourceWithStorage(
-			{{ $api.Group }}.Internal{{ $subresource.REST }},
+			{{ $api.Group }}.Internal{{ $subresource.Kind }}REST,
 			builders.SchemeFnsSingleton,
 			func() runtime.Object { return &{{ $subresource.Request }}{} }, // Register versioned resource
 			nil,
-			func() rest.Storage { return &{{ $subresource.REST }}{ {{$api.Group}}.New{{$api.Kind}}Registry({{$api.Group}}{{$api.Kind}}Storage) } },
+            {{ if $subresource.REST }}New{{ $subresource.REST }}{{ else -}}
+			func() rest.Storage { return &{{ $subresource.Kind }}REST{ {{$api.Group}}.New{{$api.Kind}}Registry({{$api.Group}}{{$api.Kind}}Storage) } },
+			{{ end -}}
 		),
 		{{ end -}}
 		{{ end -}}

--- a/cmd/apiserver-boot/boot/create/subresource.go
+++ b/cmd/apiserver-boot/boot/create/subresource.go
@@ -123,10 +123,11 @@ func createSubresource(boilerplate string) {
 			log.Fatal(err)
 		}
 		structName := fmt.Sprintf("type %s struct {", kindName)
-		sub := fmt.Sprintf("// +subresource:request=%s,path=%s,rest=%sREST",
+		sub := fmt.Sprintf("// +subresource:request=%s,path=%s,kind=%s",
 			strings.Title(a.SubresourceKind),
 			strings.ToLower(subresourceName),
-			strings.Title(a.SubresourceKind))
+			strings.Title(kindName)+strings.Title(subresourceName),
+		)
 		result := strings.Replace(string(types),
 			structName,
 			sub+"\n"+structName, 1)

--- a/example/pkg/apis/miskatonic/v1beta1/computer_student_types.go
+++ b/example/pkg/apis/miskatonic/v1beta1/computer_student_types.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/apis/miskatonic"
+)
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// +subresource-request
+type StudentComputer struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+var _ rest.CreaterUpdater = &StudentComputerREST{}
+var _ rest.Patcher = &StudentComputerREST{}
+
+// +k8s:deepcopy-gen=false
+type StudentComputerREST struct {
+	Registry miskatonic.StudentRegistry
+}
+
+func (r *StudentComputerREST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	sub := obj.(*StudentComputer)
+	return sub, nil
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StudentComputerREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return nil, nil
+}
+
+// Update alters the status subset of an object.
+func (r *StudentComputerREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return nil, false, nil
+}
+
+func (r *StudentComputerREST) New() runtime.Object {
+	return &StudentComputer{}
+}
+
+// Custom REST storage that delegates to the generated standard Registry
+func NewStudentComputerREST() rest.Storage {
+	return &StudentComputerREST{miskatonic.NewStudentRegistry(nil)}
+}

--- a/example/pkg/apis/miskatonic/v1beta1/computer_student_types_test.go
+++ b/example/pkg/apis/miskatonic/v1beta1/computer_student_types_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+
+package v1beta1_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/apis/miskatonic/v1beta1"
+	. "github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/client/clientset_generated/clientset/typed/miskatonic/v1beta1"
+)
+
+var _ = Describe("Student", func() {
+	var instance Student
+	var expected Student
+	var client StudentInterface
+
+	BeforeEach(func() {
+		instance = Student{}
+		instance.Name = "instance-1"
+
+		expected = instance
+	})
+
+	AfterEach(func() {
+		client.Delete(instance.Name, &metav1.DeleteOptions{})
+	})
+
+	Describe("when sending a computer request", func() {
+		It("should return success", func() {
+			client = cs.MiskatonicV1beta1().Students("student-test-computer")
+			_, err := client.Create(&instance)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			computer := &StudentComputer{}
+			computer.Name = instance.Name
+			restClient := cs.MiskatonicV1beta1().RESTClient()
+			err = restClient.Post().Namespace("student-test-computer").
+				Name(instance.Name).
+				Resource("students").
+				SubResource("computer").
+				Body(computer).Do().Error()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/example/pkg/apis/miskatonic/v1beta1/student_types.go
+++ b/example/pkg/apis/miskatonic/v1beta1/student_types.go
@@ -30,6 +30,7 @@ import (
 
 // +k8s:openapi-gen=true
 // +resource:path=students,rest=StudentREST
+// +subresource:request=StudentComputer,path=computer,kind=StudentComputer,rest=StudentComputerREST
 type Student struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/example/pkg/apis/miskatonic/v1beta1/university_types.go
+++ b/example/pkg/apis/miskatonic/v1beta1/university_types.go
@@ -36,7 +36,7 @@ import (
 
 // +k8s:openapi-gen=true
 // +resource:path=universities,strategy=UniversityStrategy
-// +subresource:request=UniversityCampus,path=campus,rest=UniversityCampusREST
+// +subresource:request=UniversityCampus,path=campus,kind=UniversityCampus
 type University struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Fixes: #311

now, we can add a `rest=XXX` resource tag on parent resource to support customizing REST for its subresources. additionally, a `kind=XXX` resource tag is ensured when generated.