### PR TITLE
add entry to modify the retry times in QueueWorker

### DIFF
--- a/cmd/apiregister-gen/generators/controller_generator.go
+++ b/cmd/apiregister-gen/generators/controller_generator.go
@@ -114,6 +114,11 @@ func (c *{{.Target.Kind}}Controller) GetName() string {
 	return c.Name
 }
 
+// change the retry time at runtime
+func (c *{{.Target.Kind}}Controller) SetRetryTimes(r int) {
+	c.queue.MaxRetries = r
+}
+
 func (c *{{.Target.Kind}}Controller) LookupAndReconcile(key string) (err error) {
 	return c.reconcile(key)
 }

--- a/scripts/install_etcd.sh
+++ b/scripts/install_etcd.sh
@@ -7,7 +7,7 @@ ETCD_VER=v3.2.0
 # choose either URL
 GOOGLE_URL=https://storage.googleapis.com/etcd
 GITHUB_URL=https://github.com/coreos/etcd/releases/download
-DOWNLOAD_URL=${GOOGLE_URL}
+DOWNLOAD_URL=${GITHUB_URL}
 
 rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
 rm -rf /tmp/test-etcd && mkdir -p /tmp/test-etcd


### PR DESCRIPTION
There is no entry to modify the retry times in controllers now. This means that if I want to set the retry times in queue worker, new controller need to implemented.
Adding a function to controller may be a good idea. But I am not sure if there is a better one.