### PR TITLE
Feat: Plumb generic options to new custom rest constructor

### DIFF
--- a/cmd/apiregister-gen/generators/versioned_generator.go
+++ b/cmd/apiregister-gen/generators/versioned_generator.go
@@ -54,6 +54,7 @@ func (d *versionedGenerator) Imports(c *generator.Context) []string {
 		"k8s.io/apimachinery/pkg/runtime",
 		"github.com/kubernetes-incubator/apiserver-builder-alpha/pkg/builders",
 		"k8s.io/apimachinery/pkg/runtime/schema",
+		"k8s.io/apiserver/pkg/registry/generic",
 		d.apigroup.Pkg.Path,
 	}
 	if hasSubresources(d.apiversion) {
@@ -78,7 +79,7 @@ var (
 			{{.Kind}}SchemeFns{},
 			func() runtime.Object { return &{{ $api.Kind }}{} },     // Register versioned resource
 			func() runtime.Object { return &{{ $api.Kind }}List{} }, // Register versioned resource list
-			New{{ $api.REST }},
+			{{ $api.Group }}.New{{ $api.REST }},
 		)
 	{{ else -}}
 		{{$api.Group}}{{$api.Kind}}Storage = builders.NewApiResource( // Resource status endpoint
@@ -109,8 +110,8 @@ var (
 			builders.SchemeFnsSingleton,
 			func() runtime.Object { return &{{ $subresource.Request }}{} }, // Register versioned resource
 			nil,
-            {{ if $subresource.REST }}New{{ $subresource.REST }}{{ else -}}
-			func() rest.Storage { return &{{ $subresource.Kind }}REST{ {{$api.Group}}.New{{$api.Kind}}Registry({{$api.Group}}{{$api.Kind}}Storage) } },
+            {{ if $subresource.REST }}{{ $api.Group }}.New{{ $subresource.REST }}{{ else -}}
+			func(generic.RESTOptionsGetter) rest.Storage { return &{{ $subresource.Kind }}REST{ {{$api.Group}}.New{{$api.Kind}}Registry({{$api.Group}}{{$api.Kind}}Storage) } },
 			{{ end -}}
 		),
 		{{ end -}}

--- a/example/pkg/apis/miskatonic/student_computer.go
+++ b/example/pkg/apis/miskatonic/student_computer.go
@@ -1,0 +1,42 @@
+package miskatonic
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/registry/generic"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ rest.CreaterUpdater = &StudentComputerREST{}
+var _ rest.Patcher = &StudentComputerREST{}
+
+// +k8s:deepcopy-gen=false
+type StudentComputerREST struct {
+	Registry StudentRegistry
+}
+
+func (r *StudentComputerREST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	sub := obj.(*StudentComputer)
+	return sub, nil
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StudentComputerREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return nil, nil
+}
+
+// Update alters the status subset of an object.
+func (r *StudentComputerREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return nil, false, nil
+}
+
+func (r *StudentComputerREST) New() runtime.Object {
+	return &StudentComputer{}
+}
+
+// Custom REST storage that delegates to the generated standard Registry
+func NewStudentComputerREST(getter generic.RESTOptionsGetter) rest.Storage {
+	return &StudentComputerREST{NewStudentRegistry(nil)}
+}

--- a/example/pkg/apis/miskatonic/v1beta1/computer_student_types.go
+++ b/example/pkg/apis/miskatonic/v1beta1/computer_student_types.go
@@ -17,13 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apiserver/pkg/registry/rest"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/apis/miskatonic"
 )
 
 // +genclient
@@ -35,34 +30,4 @@ type StudentComputer struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 }
 
-var _ rest.CreaterUpdater = &StudentComputerREST{}
-var _ rest.Patcher = &StudentComputerREST{}
 
-// +k8s:deepcopy-gen=false
-type StudentComputerREST struct {
-	Registry miskatonic.StudentRegistry
-}
-
-func (r *StudentComputerREST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
-	sub := obj.(*StudentComputer)
-	return sub, nil
-}
-
-// Get retrieves the object from the storage. It is required to support Patch.
-func (r *StudentComputerREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	return nil, nil
-}
-
-// Update alters the status subset of an object.
-func (r *StudentComputerREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	return nil, false, nil
-}
-
-func (r *StudentComputerREST) New() runtime.Object {
-	return &StudentComputer{}
-}
-
-// Custom REST storage that delegates to the generated standard Registry
-func NewStudentComputerREST() rest.Storage {
-	return &StudentComputerREST{miskatonic.NewStudentRegistry(nil)}
-}

--- a/example/pkg/apis/miskatonic/v1beta1/student_types.go
+++ b/example/pkg/apis/miskatonic/v1beta1/student_types.go
@@ -17,9 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/apis/miskatonic"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apiserver/pkg/registry/rest"
 )
 
 // Generating code from student_types.go file will generate storage and status REST endpoints for
@@ -48,9 +46,4 @@ type StudentSpec struct {
 type StudentStatus struct {
 	// GPA is the GPA of the student.
 	GPA float64 `json:"GPA,omitempty"`
-}
-
-// Custom REST storage that delegates to the generated standard Registry
-func NewStudentREST() rest.Storage {
-	return &miskatonic.StudentREST{miskatonic.NewStudentRegistry(nil)}
 }


### PR DESCRIPTION
1. Add generic options getter to the parameter list of custom rest func so that users can easily instantiate their own store object.

2. Move REST logic to internal packages