### PR TITLE
Feat: Support built-in admission controller for aggregated resource

### DIFF
--- a/cmd/apiregister-gen/generators/admission_generator.go
+++ b/cmd/apiregister-gen/generators/admission_generator.go
@@ -1,0 +1,101 @@
+package generators
+
+import (
+	"fmt"
+	"io"
+	"k8s.io/klog"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"k8s.io/gengo/generator"
+)
+
+var _ generator.Generator = &apiGenerator{}
+
+type admissionGenerator struct {
+	generator.DefaultGen
+	projectRootPath string
+	admissionKinds  []string
+}
+
+func CreateAdmissionGenerator(apis *APIs, filename string, projectRootPath string, outputBase string) generator.Generator {
+	admissionKinds := []string{}
+	// filter out those resources created w/ `--admission-controller` flag
+	for _, group := range apis.Groups {
+		for _, version := range group.Versions {
+			for _, resource := range version.Resources {
+				resourceAdmissionControllerPkg := filepath.Join(outputBase, projectRootPath, "plugin", "admission", strings.ToLower(resource.Kind))
+				// if "<repo>/plugin/admission" package is present in the project, add it to the generated installation function
+				if _, err := os.Stat(resourceAdmissionControllerPkg); err == nil {
+					admissionKinds = append(admissionKinds, resource.Kind)
+					klog.V(5).Infof("found existing admission controller for resource: %v/%v", resource.Group, resource.Kind)
+				}
+			}
+		}
+	}
+
+	return &admissionGenerator{
+		generator.DefaultGen{OptionalName: filename},
+		projectRootPath,
+		admissionKinds,
+	}
+}
+
+func (d *admissionGenerator) Imports(c *generator.Context) []string {
+	imports := []string{
+		"github.com/kubernetes-incubator/apiserver-builder-alpha/pkg/cmd/server",
+		"k8s.io/client-go/rest",
+		`genericserver "k8s.io/apiserver/pkg/server"`,
+	}
+	for _, kind := range d.admissionKinds {
+		imports = append(imports, fmt.Sprintf(
+			`. "%s/plugin/admission/%s"`, d.projectRootPath, strings.ToLower(kind)))
+	}
+	imports = append(imports,
+		fmt.Sprintf(`aggregatedclientset "%s/pkg/client/clientset_generated/clientset"`, d.projectRootPath))
+	imports = append(imports,
+		fmt.Sprintf(`aggregatedinformerfactory "%s/pkg/client/informers_generated/externalversions"`, d.projectRootPath))
+	imports = append(imports,
+		fmt.Sprintf(`intializer "%s/plugin/admission"`, d.projectRootPath))
+	return imports
+}
+
+type AdmissionGeneratorParam struct {
+	Kind string
+}
+
+func (d *admissionGenerator) Finalize(context *generator.Context, w io.Writer) error {
+	if len(d.admissionKinds) == 0 {
+		return nil
+	}
+
+	temp := template.Must(template.New("admission-install-template").Parse(AdmissionsInstallTemplate))
+	return temp.Execute(w, &struct {
+		Admissions []string
+	}{
+		Admissions: d.admissionKinds,
+	})
+}
+
+var AdmissionsInstallTemplate = `
+func init() {
+	server.AggregatedAdmissionInitializerGetter = GetAggregatedResourceAdmissionControllerInitializer
+{{ range .Admissions -}}
+	server.AggregatedAdmissionPlugins["{{.}}"] = New{{.}}Plugin()
+{{ end }}
+}
+
+func GetAggregatedResourceAdmissionControllerInitializer(config *rest.Config) (admission.PluginInitializer, genericserver.PostStartHookFunc) {
+	// init aggregated resource clients
+	aggregatedResourceClient := aggregatedclientset.NewForConfigOrDie(config)
+	aggregatedInformerFactory := aggregatedinformerfactory.NewSharedInformerFactory(aggregatedResourceClient, 0)
+	aggregatedResourceInitializer := intializer.New(aggregatedResourceClient, aggregatedInformerFactory)
+
+	return aggregatedResourceInitializer, func(context genericserver.PostStartHookContext) error {
+		aggregatedInformerFactory.Start(context.StopCh)
+		return nil
+	}
+}
+`

--- a/cmd/apiregister-gen/generators/package.go
+++ b/cmd/apiregister-gen/generators/package.go
@@ -104,9 +104,14 @@ func (g *Gen) Packages(context *generator.Context, arguments *args.GeneratorArgs
 		g.p = append(g.p, factory.createPackage(gen))
 	}
 
-	factory := &packageFactory{b.APIs.Pkg.Path, arguments}
+	apisFactory := &packageFactory{b.APIs.Pkg.Path, arguments}
 	gen := CreateApisGenerator(b.APIs, arguments.OutputFileBaseName)
-	g.p = append(g.p, factory.createPackage(gen))
+	g.p = append(g.p, apisFactory.createPackage(gen))
+
+	projectRootPath := filepath.Dir(filepath.Dir(b.APIs.Pkg.Path))
+	admissionFactory := &packageFactory{filepath.Join(projectRootPath, "plugin", "admission", "install"), arguments}
+	admissionGen := CreateAdmissionGenerator(b.APIs, arguments.OutputFileBaseName, projectRootPath, b.arguments.OutputBase)
+	g.p = append(g.p, admissionFactory.createPackage(admissionGen))
 	return g.p
 }
 

--- a/example/cmd/apiserver/main.go
+++ b/example/cmd/apiserver/main.go
@@ -20,8 +20,17 @@ import (
 	"github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/apis"
 	"github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/openapi"
 	"github.com/kubernetes-incubator/apiserver-builder-alpha/pkg/cmd/server"
+
+	// import the package to install custom admission controllers and custom admission initializers
+	_ "github.com/kubernetes-incubator/apiserver-builder-alpha/example/plugin/admission/install"
 )
 
 func main() {
-	server.StartApiServer("/registry/sample.kubernetes.io", apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions, "Api", "v0")
+	server.StartApiServer(
+		"/registry/sample.kubernetes.io",
+		apis.GetAllApiBuilders(),
+		openapi.GetOpenAPIDefinitions,
+		"Api",
+		"v0",
+	)
 }

--- a/example/plugin/admission/deepone/admission.go
+++ b/example/plugin/admission/deepone/admission.go
@@ -1,0 +1,70 @@
+
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+
+package deeponeadmission
+
+import (
+	"fmt"
+	aggregatedadmission "github.com/kubernetes-incubator/apiserver-builder-alpha/example/plugin/admission"
+	aggregatedinformerfactory "github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/client/informers_generated/externalversions"
+	aggregatedclientset "github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/client/clientset_generated/clientset"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+var _ admission.Interface 											= &deeponePlugin{}
+var _ admission.MutationInterface 									= &deeponePlugin{}
+var _ admission.ValidationInterface 								= &deeponePlugin{}
+var _ genericadmissioninitializer.WantsExternalKubeInformerFactory 	= &deeponePlugin{}
+var _ genericadmissioninitializer.WantsExternalKubeClientSet 		= &deeponePlugin{}
+var _ aggregatedadmission.WantsAggregatedResourceInformerFactory 	= &deeponePlugin{}
+var _ aggregatedadmission.WantsAggregatedResourceClientSet 			= &deeponePlugin{}
+
+func NewDeepOnePlugin() *deeponePlugin {
+	return &deeponePlugin{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}
+
+type deeponePlugin struct {
+	*admission.Handler
+}
+
+func (p *deeponePlugin) ValidateInitialization() error {
+	return nil
+}
+
+func (p *deeponePlugin) Admit(a admission.Attributes) error {
+	fmt.Println("admitting deepones")
+	return nil
+}
+
+func (p *deeponePlugin) Validate(a admission.Attributes) error {
+	return nil
+}
+
+func (p *deeponePlugin) SetAggregatedResourceInformerFactory(aggregatedinformerfactory.SharedInformerFactory) {}
+
+func (p *deeponePlugin) SetAggregatedResourceClientSet(aggregatedclientset.Interface) {}
+
+func (p *deeponePlugin) SetExternalKubeInformerFactory(informers.SharedInformerFactory) {}
+
+func (p *deeponePlugin) SetExternalKubeClientSet(kubernetes.Interface) {}

--- a/example/plugin/admission/festival/admission.go
+++ b/example/plugin/admission/festival/admission.go
@@ -1,0 +1,70 @@
+
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+
+package festivaladmission
+
+import (
+	"fmt"
+	aggregatedadmission "github.com/kubernetes-incubator/apiserver-builder-alpha/example/plugin/admission"
+	aggregatedinformerfactory "github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/client/informers_generated/externalversions"
+	aggregatedclientset "github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/client/clientset_generated/clientset"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+var _ admission.Interface 											= &festivalPlugin{}
+var _ admission.MutationInterface 									= &festivalPlugin{}
+var _ admission.ValidationInterface 								= &festivalPlugin{}
+var _ genericadmissioninitializer.WantsExternalKubeInformerFactory 	= &festivalPlugin{}
+var _ genericadmissioninitializer.WantsExternalKubeClientSet 		= &festivalPlugin{}
+var _ aggregatedadmission.WantsAggregatedResourceInformerFactory 	= &festivalPlugin{}
+var _ aggregatedadmission.WantsAggregatedResourceClientSet 			= &festivalPlugin{}
+
+func NewFestivalPlugin() *festivalPlugin {
+	return &festivalPlugin{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}
+
+type festivalPlugin struct {
+	*admission.Handler
+}
+
+func (p *festivalPlugin) ValidateInitialization() error {
+	return nil
+}
+
+func (p *festivalPlugin) Admit(a admission.Attributes) error {
+	fmt.Println("admitting festivals")
+	return nil
+}
+
+func (p *festivalPlugin) Validate(a admission.Attributes) error {
+	return nil
+}
+
+func (p *festivalPlugin) SetAggregatedResourceInformerFactory(aggregatedinformerfactory.SharedInformerFactory) {}
+
+func (p *festivalPlugin) SetAggregatedResourceClientSet(aggregatedclientset.Interface) {}
+
+func (p *festivalPlugin) SetExternalKubeInformerFactory(informers.SharedInformerFactory) {}
+
+func (p *festivalPlugin) SetExternalKubeClientSet(kubernetes.Interface) {}

--- a/example/plugin/admission/initializer.go
+++ b/example/plugin/admission/initializer.go
@@ -1,0 +1,64 @@
+
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+
+package admission
+
+import (
+	aggregatedclientset "github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/client/clientset_generated/clientset"
+	aggregatedinformerfactory "github.com/kubernetes-incubator/apiserver-builder-alpha/example/pkg/client/informers_generated/externalversions"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+// WantsAggregatedResourceClientSet defines a function which sets external ClientSet for admission plugins that need it
+type WantsAggregatedResourceClientSet interface {
+	SetAggregatedResourceClientSet(aggregatedclientset.Interface)
+	admission.InitializationValidator
+}
+
+// WantsAggregatedResourceInformerFactory defines a function which sets InformerFactory for admission plugins that need it
+type WantsAggregatedResourceInformerFactory interface {
+	SetAggregatedResourceInformerFactory(aggregatedinformerfactory.SharedInformerFactory)
+	admission.InitializationValidator
+}
+
+// New creates an instance of admission plugins initializer.
+func New(
+	clientset aggregatedclientset.Interface,
+	informers aggregatedinformerfactory.SharedInformerFactory,
+) pluginInitializer {
+	return pluginInitializer{
+		aggregatedResourceClient:    clientset,
+		aggregatedResourceInformers: informers,
+	}
+}
+
+type pluginInitializer struct {
+	aggregatedResourceClient    aggregatedclientset.Interface
+	aggregatedResourceInformers aggregatedinformerfactory.SharedInformerFactory
+}
+
+func (i pluginInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsAggregatedResourceClientSet); ok {
+		wants.SetAggregatedResourceClientSet(i.aggregatedResourceClient)
+	}
+	if wants, ok := plugin.(WantsAggregatedResourceInformerFactory); ok {
+		wants.SetAggregatedResourceInformerFactory(i.aggregatedResourceInformers)
+	}
+}
+

--- a/pkg/cmd/server/admission.go
+++ b/pkg/cmd/server/admission.go
@@ -1,0 +1,12 @@
+package server
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	AggregatedAdmissionInitializerGetter func(config *rest.Config) (admission.PluginInitializer, genericapiserver.PostStartHookFunc)
+	AggregatedAdmissionPlugins           = make(map[string]admission.Interface)
+)


### PR DESCRIPTION
a dummy admission controller will be generated when specifying `--admission-controller` in the `apiserver-boot create resource` commands.