### PR TITLE
fix invalid resource version in example

### DIFF
--- a/cmd/apiserver-boot/boot/create/create.go
+++ b/cmd/apiserver-boot/boot/create/create.go
@@ -24,7 +24,7 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Command group for bootstrapping new resources.",
 	Long:  `Command group for bootstrapping new resources.`,
-	Example: `# Create new resource "Bee" in the "insect" group with version "v1beta"
+	Example: `# Create new resource "Bee" in the "insect" group with version "v1beta1"
 # Will automatically the group and version if they do not exist
 apiserver-boot create group version resource --group insect --version v1beta1 --kind Bee
 
@@ -33,7 +33,7 @@ apiserver-boot create group --group insect
 
 # Create a new version "v1beta" of group "insect"
 # Will automatically create group if it does not exist
-apiserver-boot create group --group insect --version v1beta`,
+apiserver-boot create group --group insect --version v1beta1`,
 	Run: RunCreate,
 }
 

--- a/cmd/apiserver-boot/boot/create/resource.go
+++ b/cmd/apiserver-boot/boot/create/resource.go
@@ -46,9 +46,9 @@ var createResourceCmd = &cobra.Command{
 	Use:   "resource",
 	Short: "Creates an API group, version and resource",
 	Long:  `Creates an API group, version and resource.  Will not recreate group or resource if they already exist.  Creates file pkg/apis/<group>/<version>/<kind>_types.go`,
-	Example: `# Create new resource "Bee" in the "insect" group with version "v1beta"
+	Example: `# Create new resource "Bee" in the "insect" group with version "v1beta1"
 # Will automatically the group and version if they do not exist
-apiserver-boot create group version resource --group insect --version v1beta --kind Bee`,
+apiserver-boot create group version resource --group insect --version v1beta1 --kind Bee`,
 	Run: RunCreateResource,
 }
 

--- a/cmd/apiserver-boot/boot/create/subresource.go
+++ b/cmd/apiserver-boot/boot/create/subresource.go
@@ -36,8 +36,8 @@ var createSubresourceCmd = &cobra.Command{
 	Use:   "subresource",
 	Short: "Creates a subresource",
 	Long:  `Creates a subresource.  Creates file pkg/apis/<group>/<version>/<subresourceName>_<kind>_types.go and updates pkg/apis/<group>/<version>/<kind>_types.go with the subresource comment directive.`,
-	Example: `# Create new subresource "pollinate" of resource "Bee" in the "insect" group with version "v1beta"
-apiserver-boot create subresource --subresource pollinate --group insect --version v1beta --kind Bee`,
+	Example: `# Create new subresource "pollinate" of resource "Bee" in the "insect" group with version "v1beta1"
+apiserver-boot create subresource --subresource pollinate --group insect --version v1beta1 --kind Bee`,
 	Run: RunCreateSubresource,
 }
 

--- a/cmd/apiserver-boot/main.go
+++ b/cmd/apiserver-boot/main.go
@@ -72,8 +72,8 @@ var cmd = &cobra.Command{
 	Example: `# Initialize your repository with scaffolding directories and go files.
 apiserver-boot init repo --domain example.com
 
-# Create new resource "Bee" in the "insect" group with version "v1beta"
-apiserver-boot create group version resource --group insect --version v1beta --kind Bee
+# Create new resource "Bee" in the "insect" group with version "v1beta1"
+apiserver-boot create group version resource --group insect --version v1beta1 --kind Bee
 
 # Build the generated code, apiserver and controller-manager so they be run locally.
 apiserver-boot build executables


### PR DESCRIPTION
fix invalid resource version in example:
```
apiserver-boot create group version resource --group insect --version v1beta --kind Bee
2019/08/01 13:33:54 --version has bad format. must match ^v\d+(alpha\d+|beta\d+)*$.  e.g. v1alpha1,v1beta1,v1 but was (v1beta)
```
